### PR TITLE
chore: use a much faster implementation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,39 +15,36 @@ clone({a: 1, b: {c: 2}}) // => {a: 1, b: {c: 2}}
 
 #### `proto` option
 
-It's faster to allow enumerable properties on the prototype 
-to be copied into the cloned object (not onto it's prototype,
-directly onto the object).
+It's faster to allow enumerable properties on the prototype to be copied into
+the cloned object (not onto it's prototype, directly onto the object).
 
-To explain by way of code: 
+To explain by way of code:
 
 ```js
 require('rfdc')({ proto: false })(Object.create({a: 1})) // => {}
 require('rfdc')({ proto: true })(Object.create({a: 1})) // => {a: 1}
-``` 
+```
 
-If this behavior is acceptable, set
-`proto` to `true` for an additional 15% performance boost
-(see benchmarks).
+If this behavior is acceptable, set `proto` to `true` for an additional 2%
+performance boost.
 
 #### `circles` option
 
-Keeping track of circular references will slow down performance
-with an additional 40%-50% overhead (even if an object doesn't have
-any circular references, the tracking is the cost). By default if 
-an object with a circular reference is passed in, `rfdc` will throw (similar to
-how `JSON.stringify` would throw). 
+Keeping track of circular references will slow down performance with an
+additional 25% overhead (even if an object doesn't have any circular references,
+the tracking is the cost). By default if an object with a circular reference is
+passed in, `rfdc` will throw (similar to how `JSON.stringify` would throw).
 
-Use the `circles` option to detect and preserve circular references
-in the object. If performance is important, try removing the 
-circular reference from the object (set to `undefined`) and then
-add it back manually after cloning instead of using this option.
+Use the `circles` option to detect and preserve circular references in the
+object. If performance is important, try removing the circular reference from
+the object (set to `undefined`) and then add it back manually after cloning
+instead of using this option.
 
 ### Types
 
 `rdfc` clones all JSON types:
 
-* `Object` 
+* `Object`
 * `Array`
 * `Number`
 * `String`
@@ -65,7 +62,7 @@ With additional support for:
 All other types have output values that match the output
 of `JSON.parse(JSON.stringify(o))`.
 
-For instance: 
+For instance:
 
 ```js
 const rdfc = require('rdfc')()
@@ -88,13 +85,13 @@ npm run bench
 ```
 
 ```
-benchDeepCopy*100: 687.014ms
-benchLodashCloneDeep*100: 1803.993ms
-benchFastCopy*100: 929.259ms
-benchRfdc*100: 565.133ms
-benchRfdcProto*100: 484.401ms
-benchRfdcCircles*100: 846.672ms
-benchRfdcCirclesProto*100: 752.908ms
+benchDeepCopy*100: 716.764ms
+benchLodashCloneDeep*100: 1900.503ms
+benchFastCopy*100: 1036.360ms
+benchRfdc*100: 408.775ms
+benchRfdcProto*100: 411.914ms
+benchRfdcCircles*100: 529.198ms
+benchRfdcCirclesProto*100: 519.694ms
 ```
 
 ## Tests
@@ -104,13 +101,13 @@ npm test
 ```
 
 ```
-148 passing (365.985ms)
+169 passing (625.569ms)
 ```
 
 ### Coverage
 
 ```sh
-npm run cov 
+npm run cov
 ```
 
 ```

--- a/test/index.js
+++ b/test/index.js
@@ -26,7 +26,7 @@ test('circles option - circular object', async ({same, is, isNot}) => {
   isNot(cloneCircles(o).nest, o.nest, 'different nested objects')
   const c = cloneCircles(o)
   is(c.circular, c, 'circular references point to copied parent')
-  isNot(c.circular, o, 'circular references do not point to original parent') 
+  isNot(c.circular, o, 'circular references do not point to original parent')
 })
 test('circles option – deep circular object', async ({same, is, isNot}) => {
   const o = {nest: {a: 1, b: 2}}
@@ -36,7 +36,7 @@ test('circles option – deep circular object', async ({same, is, isNot}) => {
   isNot(cloneCircles(o).nest, o.nest, 'different nested objects')
   const c = cloneCircles(o)
   is(c.nest.circular, c, 'circular references point to copied parent')
-  isNot(c.nest.circular, o, 'circular references do not point to original parent') 
+  isNot(c.nest.circular, o, 'circular references do not point to original parent')
 })
 test('circles option alone – does not copy proto properties', async ({is}) => {
   is(cloneCircles(Object.create({a: 1})).a, undefined, 'value not copied')
@@ -52,7 +52,7 @@ test('circles and proto option - circular object', async ({same, is, isNot}) => 
   isNot(cloneCirclesProto(o).nest, o.nest, 'different nested objects')
   const c = cloneCirclesProto(o)
   is(c.circular, c, 'circular references point to copied parent')
-  isNot(c.circular, o, 'circular references do not point to original parent') 
+  isNot(c.circular, o, 'circular references do not point to original parent')
 })
 test('circles and proto option – deep circular object', async ({same, is, isNot}) => {
   const o = {nest: {a: 1, b: 2}}
@@ -62,10 +62,20 @@ test('circles and proto option – deep circular object', async ({same, is, isNo
   isNot(cloneCirclesProto(o).nest, o.nest, 'different nested objects')
   const c = cloneCirclesProto(o)
   is(c.nest.circular, c, 'circular references point to copied parent')
-  isNot(c.nest.circular, o, 'circular references do not point to original parent') 
+  isNot(c.nest.circular, o, 'circular references do not point to original parent')
+})
+test('circles and proto option – deep circular array', async ({same, is, isNot}) => {
+  const o = {nest: [1, 2] }
+  o.nest.push(o)
+  same(cloneCirclesProto(o), o, 'same values')
+  isNot(cloneCirclesProto(o), o, 'different objects')
+  isNot(cloneCirclesProto(o).nest, o.nest, 'different nested objects')
+  const c = cloneCirclesProto(o)
+  is(c.nest[2], c, 'circular references point to copied parent')
+  isNot(c.nest[2], o, 'circular references do not point to original parent')
 })
 
-function types(clone, label) {
+function types (clone, label) {
   test(label + ' – number', async ({is}) => {
     is(clone(42), 42, 'same value')
   })
@@ -143,6 +153,13 @@ function types(clone, label) {
     const date = new Date()
     is(+clone({d: date}).d, +date, 'same value')
     isNot(clone({d: date}).d, date, 'different object')
+  })
+  test(label + ' – nested date in array', async ({is, isNot}) => {
+    const date = new Date()
+    is(+clone({d: [date]}).d[0], +date, 'same value')
+    isNot(clone({d: [date]}).d[0], date, 'different object')
+    is(+cloneCircles({d: [date]}).d[0], +date, 'same value')
+    isNot(cloneCircles({d: [date]}).d, date, 'different object')
   })
   test(label + ' – nested null', async ({is}) => {
     is(clone({n: null}).n, null, 'same value')


### PR DESCRIPTION
This improves the performance significantly. The proto option is
almost obsolete now as it should be (V8 highly optimized this) and
circular structures are not as costy anymore. Regular copying is
also significantly faster, especially for arrays.

I also fixed linting issues while being on it.