### PR TITLE
Return modifiable objects

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,11 @@ declare namespace rfdc {
   }
 }
 
-declare function rfdc(options?: rfdc.Options): <T>(input: T) => T;
+declare type DeepReadwrite<T> = T extends {} | []
+  ? { -readonly [P in keyof T]: DeepReadwrite<T[P]> }
+  : T;
+declare function rfdc(
+  options?: rfdc.Options
+): <T>(input: T) => DeepReadwrite<T>;
 
 export = rfdc;


### PR DESCRIPTION
Remove `readonly` attributes throughout the returned object tree

Fixes #30 