### PR TITLE
🏷️ Add type definitions for `constructorHandlers` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,8 +2,11 @@ declare namespace rfdc {
   interface Options {
     proto?: boolean;
     circles?: boolean;
+    constructorHandlers?: ConstructorHandlerConfig[];
   }
 }
+type Constructor<T> = {new(...args: any[]): T};
+type ConstructorHandlerConfig<T = any> = [Constructor<T>, (o: T) => T];
 
 declare function rfdc(options?: rfdc.Options): <T>(input: T) => T;
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -5,3 +5,9 @@ const clone = rfdc();
 
 expectType<number>(clone(5));
 expectType<{ lorem: string }>(clone({ lorem: "ipsum" }));
+
+const cloneHandlers = rfdc({
+  constructorHandlers: [
+    [RegExp, (o) => new RegExp(o)],
+  ],
+})


### PR DESCRIPTION
Adds TypeScript definitions for https://github.com/davidmarkclements/rfdc/pull/40